### PR TITLE
configure: Fix bashisms

### DIFF
--- a/configure
+++ b/configure
@@ -11,7 +11,7 @@
 # Help
 #------------------------------------------------------------------------------
 
-function show_help() {
+show_help() {
     cat <<!
 Usage: ./configure [options]
 Options are :
@@ -23,7 +23,7 @@ Options are :
 # Helper function
 #------------------------------------------------------------------------------
 
-function check_status() {
+check_status() {
 if [ $1 -eq 0 ]; then
     echo yes
 else
@@ -37,7 +37,7 @@ fi
 # Checks for gcc
 #------------------------------------------------------------------------------
 
-function check_gcc() {
+check_gcc() {
 
     printf "Checking if gcc exists... "
     gcc -v 2>/dev/null
@@ -74,7 +74,7 @@ int main(void)
 # Check for make
 #------------------------------------------------------------------------------
 
-function check_make() {
+check_make() {
     printf "Checking if make exists... "
     make -v >/dev/null
     check_status $?
@@ -84,7 +84,7 @@ function check_make() {
 # Check for autogen
 #------------------------------------------------------------------------------
 
-function check_autogen() {
+check_autogen() {
     printf "Checking if autogen exists... "
     autogen -v >/dev/null
     check_status $?
@@ -94,7 +94,7 @@ function check_autogen() {
 # Check for autoconf
 #------------------------------------------------------------------------------
 
-function check_autoconf() {
+check_autoconf() {
     printf "Checking if autoconf exists... "
     autoconf -V >/dev/null
     check_status $?
@@ -104,7 +104,7 @@ function check_autoconf() {
 # Check for automake
 #------------------------------------------------------------------------------
 
-function check_automake() {
+check_automake() {
     printf "Checking if automake exists... "
     automake --version >/dev/null
     check_status $?


### PR DESCRIPTION
Interpreter is set to /bin/sh which might be strict about POSIX syntax.

This fixes errors I get on Debian:
```
./configure: 14: Syntax error: "(" unexpected
```